### PR TITLE
`Htttp` facade & `DependencyUrl` generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,8 @@ All notable changes to `dependencies` will be documented in this file
 ## 0.1.1 - 2021-07-08
 - add url & response contains assertions
 - add packages to the dataProvider
+
+
+## 0.2.0 - 2021-07-09
+- refactor test suite to use `Http` facade instead of `GuzzleHttp\Client`
+- refactor `DependencyService` methods to return an instance of `DependencyUrl` for retrieving urls & svgs

--- a/src/DependenciesRepository.php
+++ b/src/DependenciesRepository.php
@@ -3,7 +3,7 @@
 namespace Sfneal\Dependencies;
 
 use Illuminate\Support\Collection;
-use Sfneal\Dependencies\Utils\DependenciesService;
+use Sfneal\Dependencies\Services\DependenciesService;
 use Sfneal\Helpers\Strings\StringHelpers;
 
 class DependenciesRepository

--- a/src/DependenciesRepository.php
+++ b/src/DependenciesRepository.php
@@ -3,6 +3,7 @@
 namespace Sfneal\Dependencies;
 
 use Illuminate\Support\Collection;
+use Sfneal\Dependencies\Utils\DependenciesService;
 use Sfneal\Helpers\Strings\StringHelpers;
 
 class DependenciesRepository

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\Dependencies\Utils;
+namespace Sfneal\Dependencies\Services;
 
 class DependenciesService
 {

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -2,6 +2,9 @@
 
 namespace Sfneal\Dependencies\Services;
 
+use Sfneal\Dependencies\Utils\DependencySvg;
+use Sfneal\Dependencies\Utils\DependencyUrl;
+
 class DependenciesService
 {
     /**
@@ -28,94 +31,73 @@ class DependenciesService
     /**
      * Retrieve a GitHub URL for a dependency.
      *
-     * @return string
+     * @return DependencyUrl
      */
-    public function gitHub(): string
+    public function gitHub(): DependencyUrl
     {
-        return self::url("github.com/{$this->package}");
+        return new DependencyUrl("github.com/{$this->package}");
     }
 
     /**
      * Retrieve a Travis CI build status SVG URL for a dependency.
      *
-     * @param bool $svg
-     * @return string
+     * @return DependencySvg
      */
-    public function travis(bool $svg = false): string
+    public function travis(): DependencySvg
     {
-        return self::url("travis-ci.com/{$this->package}".($svg ? '.svg?branch=master' : ''));
+        return new DependencySvg(
+            "travis-ci.com/{$this->package}",
+            "travis-ci.com/{$this->package}.svg?branch=master",
+            ''
+        );
     }
 
     /**
      * Retrieve the Dependencies latest version.
      *
-     * @param bool $svg
-     * @return string
+     * @return DependencySvg
      */
-    public function version(bool $svg = false): string
+    public function version(): DependencySvg
     {
-        return $this->type == 'composer' ? $this->packagist($svg) : $this->docker($svg);
+        return $this->type == 'composer' ? $this->packagist() : $this->docker();
     }
 
     /**
      * Retrieve date of the last GitHub commit.
      *
-     * @return string
+     * @return DependencySvg
      */
-    public function lastCommit(): string
+    public function lastCommit(): DependencySvg
     {
-        return self::imgShieldUrl("/github/last-commit/{$this->package}");
+        return new DependencySvg(
+            "github.com/{$this->package}",
+            "github/last-commit/{$this->package}"
+        );
     }
 
     /**
      * Retrieve a Packagist versions SVG URL for a dependency.
      *
-     * @param bool $svg
-     * @return string
+     * @return DependencySvg
      */
-    private function packagist(bool $svg = false): string
+    private function packagist(): DependencySvg
     {
-        if ($svg) {
-            return self::imgShieldUrl("/packagist/v/{$this->package}.svg");
-        } else {
-            return self::url("packagist.org/packages/{$this->package}");
-        }
+        return new DependencySvg(
+            "packagist.org/packages/{$this->package}",
+            "packagist/v/{$this->package}.svg"
+        );
     }
 
     /**
      * Retrieve the latest Docker image tag for a dependency.
      *
-     * @param bool $svg
-     * @return string
+     * @return DependencySvg
      */
-    private function docker(bool $svg = false): string
+    private function docker(): DependencySvg
     {
-        if ($svg) {
-            return self::imgShieldUrl("/docker/v/{$this->package}.svg?sort=semver");
-        } else {
-            return self::url("hub.docker.com/r/{$this->package}");
-        }
-    }
-
-    /**
-     * Retrieve a image shield url.
-     *
-     * @param string $endpoint
-     * @return string
-     */
-    private static function imgShieldUrl(string $endpoint): string
-    {
-        return self::url('img.shields.io'.$endpoint);
-    }
-
-    /**
-     * Retrieve a secure url.
-     *
-     * @param string $uri
-     * @return string
-     */
-    private static function url(string $uri): string
-    {
-        return 'http'."://{$uri}";
+        return new DependencySvg(
+            "hub.docker.com/r/{$this->package}",
+            "docker/v/{$this->package}.svg?sort=semver"
+        );
     }
 }

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -32,7 +32,7 @@ class DependenciesService
      */
     public function gitHub(): string
     {
-        return self::url("github.com/{$this->packageName()}");
+        return self::url("github.com/{$this->package}");
     }
 
     /**
@@ -43,7 +43,7 @@ class DependenciesService
      */
     public function travis(bool $svg = false): string
     {
-        return self::url("travis-ci.com/{$this->packageName()}".($svg ? '.svg?branch=master' : ''));
+        return self::url("travis-ci.com/{$this->package}".($svg ? '.svg?branch=master' : ''));
     }
 
     /**
@@ -64,7 +64,7 @@ class DependenciesService
      */
     public function lastCommit(): string
     {
-        return self::imgShieldUrl("/github/last-commit/{$this->packageName()}");
+        return self::imgShieldUrl("/github/last-commit/{$this->package}");
     }
 
     /**
@@ -95,20 +95,6 @@ class DependenciesService
         } else {
             return self::url("hub.docker.com/r/{$this->package}");
         }
-    }
-
-    /**
-     * Retrieve the correct name for a package.
-     *
-     * @return string
-     */
-    private function packageName(): string
-    {
-        if ($this->type == 'docker') {
-            return str_replace('stephenneal', 'sfneal', $this->package);
-        }
-
-        return $this->package;
     }
 
     /**

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -126,11 +126,10 @@ class DependenciesService
      * Retrieve a secure url.
      *
      * @param string $uri
-     * @param bool $secure use https
      * @return string
      */
-    private static function url(string $uri, bool $secure = true): string
+    private static function url(string $uri): string
     {
-        return 'http'.($secure ? 's' : '')."://{$uri}";
+        return 'http'."://{$uri}";
     }
 }

--- a/src/Utils/DependenciesService.php
+++ b/src/Utils/DependenciesService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\Dependencies;
+namespace Sfneal\Dependencies\Utils;
 
 class DependenciesService
 {

--- a/src/Utils/DependencySvg.php
+++ b/src/Utils/DependencySvg.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Dependencies\Utils;
-
 
 class DependencySvg extends DependencyUrl
 {

--- a/src/Utils/DependencySvg.php
+++ b/src/Utils/DependencySvg.php
@@ -12,14 +12,21 @@ class DependencySvg extends DependencyUrl
     private $svg;
 
     /**
+     * @var string
+     */
+    private $baseUrl;
+
+    /**
      * DependencySvg constructor.
      * @param string $uri
      * @param string $svg
+     * @param string $baseUrl
      */
-    public function __construct(string $uri, string $svg)
+    public function __construct(string $uri, string $svg, string $baseUrl = 'img.shields.io/')
     {
         parent::__construct($uri);
         $this->svg = $svg;
+        $this->baseUrl = $baseUrl;
     }
 
     /**
@@ -29,6 +36,6 @@ class DependencySvg extends DependencyUrl
      */
     public function svg(): string
     {
-        return $this->url('img.shields.io'.$this->svg);
+        return self::generateUrl($this->baseUrl.$this->svg);
     }
 }

--- a/src/Utils/DependencySvg.php
+++ b/src/Utils/DependencySvg.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace Sfneal\Dependencies\Utils;
+
+
+class DependencySvg extends DependencyUrl
+{
+    /**
+     * @var string
+     */
+    private $svg;
+
+    /**
+     * DependencySvg constructor.
+     * @param string $uri
+     * @param string $svg
+     */
+    public function __construct(string $uri, string $svg)
+    {
+        parent::__construct($uri);
+        $this->svg = $svg;
+    }
+
+    /**
+     * Retrieve a dependency SVG image.
+     *
+     * @return string
+     */
+    public function svg(): string
+    {
+        return $this->url('img.shields.io'.$this->svg);
+    }
+}

--- a/src/Utils/DependencyUrl.php
+++ b/src/Utils/DependencyUrl.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Dependencies\Utils;
-
 
 class DependencyUrl
 {

--- a/src/Utils/DependencyUrl.php
+++ b/src/Utils/DependencyUrl.php
@@ -24,11 +24,21 @@ class DependencyUrl
     /**
      * Retrieve the Dependency URL.
      *
-     * @param string|null $uri
      * @return string
      */
-    public function url(string $uri = null): string
+    public function url(): string
     {
-        return 'https://'.$uri ?? $this->uri;
+        return self::generateUrl($this->uri);
+    }
+
+    /**
+     * Generate a URL.
+     *
+     * @param string $uri
+     * @return string
+     */
+    protected static function generateUrl(string $uri): string
+    {
+        return 'https://'.$uri;
     }
 }

--- a/src/Utils/DependencyUrl.php
+++ b/src/Utils/DependencyUrl.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace Sfneal\Dependencies\Utils;
+
+
+class DependencyUrl
+{
+    /**
+     * @var string
+     */
+    private $uri;
+
+    /**
+     * DependencyUrl constructor.
+     *
+     * @param string $uri
+     */
+    public function __construct(string $uri)
+    {
+        $this->uri = $uri;
+    }
+
+    /**
+     * Retrieve the Dependency URL.
+     *
+     * @param string|null $uri
+     * @return string
+     */
+    public function url(string $uri = null): string
+    {
+        return 'https://'.$uri ?? $this->uri;
+    }
+}

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -4,6 +4,7 @@ namespace Sfneal\Dependencies\Tests\Feature;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Http;
 use Sfneal\Dependencies\Tests\TestCase;
 use Sfneal\Dependencies\Utils\DependenciesService;
 
@@ -13,102 +14,93 @@ class DependencyServiceTest extends TestCase
      * @test
      * @dataProvider packageProvider
      * @param string $package
-     * @throws GuzzleException
      */
     public function github_url(string $package)
     {
         $url = (new DependenciesService($package))->gitHub();
-        $response = (new Client())->request('get', $url);
+        $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('github.com', $url);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue($response->ok());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
-     * @throws GuzzleException
      */
     public function travis_url(string $package)
     {
         $url = (new DependenciesService($package))->travis();
-        $response = (new Client())->request('get', $url);
+        $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('travis-ci.com', $url);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue($response->ok());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
-     * @throws GuzzleException
      */
     public function version_url(string $package)
     {
         $url = (new DependenciesService($package))->version();
-        $response = (new Client())->request('get', $url);
+        $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('packagist.org/packages', $url);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue($response->ok());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
-     * @throws GuzzleException
      */
     public function travis_svg(string $package)
     {
         $url = (new DependenciesService($package))->travis(true);
-        $response = (new Client())->request('get', $url);
-        $contents = $response->getBody()->getContents();
+        $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('travis-ci.com', $url);
         $this->assertStringContainsString('.svg?branch=master', $url);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertStringContainsString('build', $contents);
+        $this->assertTrue($response->ok());
+        $this->assertStringContainsString('build', $response->body());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
-     * @throws GuzzleException
      */
     public function version_svg(string $package)
     {
         $url = (new DependenciesService($package))->version(true);
-        $response = (new Client())->request('get', $url);
-        $contents = $response->getBody()->getContents();
+        $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('img.shields.io/packagist/v', $url);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertStringContainsString('<title>packagist: v', $contents);
+        $this->assertTrue($response->ok());
+        $this->assertStringContainsString('<title>packagist: v', $response->body());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
-     * @throws GuzzleException
      */
     public function last_commit_svg(string $package)
     {
         $url = (new DependenciesService($package))->lastCommit();
-        $response = (new Client())->request('get', $url);
-        $contents = $response->getBody()->getContents();
+        $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('img.shields.io/github/last-commit', $url);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertStringContainsString('last commit', $contents);
+        $this->assertTrue($response->ok());
+        $this->assertStringContainsString('last commit', $response->body());
     }
 }

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -15,7 +15,9 @@ class DependencyServiceTest extends TestCase
      */
     public function github_url(string $package)
     {
-        $url = (new DependenciesService($package))->gitHub();
+        $url = (new DependenciesService($package))
+            ->gitHub()
+            ->url();
         $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
@@ -30,7 +32,9 @@ class DependencyServiceTest extends TestCase
      */
     public function travis_url(string $package)
     {
-        $url = (new DependenciesService($package))->travis();
+        $url = (new DependenciesService($package))
+            ->travis()
+            ->url();
         $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
@@ -45,7 +49,9 @@ class DependencyServiceTest extends TestCase
      */
     public function version_url(string $package)
     {
-        $url = (new DependenciesService($package))->version();
+        $url = (new DependenciesService($package))
+            ->version()
+            ->url();
         $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
@@ -60,7 +66,9 @@ class DependencyServiceTest extends TestCase
      */
     public function travis_svg(string $package)
     {
-        $url = (new DependenciesService($package))->travis(true);
+        $url = (new DependenciesService($package))
+            ->travis()
+            ->svg();
         $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
@@ -77,7 +85,9 @@ class DependencyServiceTest extends TestCase
      */
     public function version_svg(string $package)
     {
-        $url = (new DependenciesService($package))->version(true);
+        $url = (new DependenciesService($package))
+            ->version()
+            ->svg();
         $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);
@@ -93,7 +103,9 @@ class DependencyServiceTest extends TestCase
      */
     public function last_commit_svg(string $package)
     {
-        $url = (new DependenciesService($package))->lastCommit();
+        $url = (new DependenciesService($package))
+            ->lastCommit()
+            ->svg();
         $response = Http::get($url);
 
         $this->assertStringContainsString($package, $url);

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -3,8 +3,8 @@
 namespace Sfneal\Dependencies\Tests\Feature;
 
 use Illuminate\Support\Facades\Http;
+use Sfneal\Dependencies\Services\DependenciesService;
 use Sfneal\Dependencies\Tests\TestCase;
-use Sfneal\Dependencies\Utils\DependenciesService;
 
 class DependencyServiceTest extends TestCase
 {

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -4,8 +4,8 @@ namespace Sfneal\Dependencies\Tests\Feature;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use Sfneal\Dependencies\DependenciesService;
 use Sfneal\Dependencies\Tests\TestCase;
+use Sfneal\Dependencies\Utils\DependenciesService;
 
 class DependencyServiceTest extends TestCase
 {

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -5,6 +5,8 @@ namespace Sfneal\Dependencies\Tests\Feature;
 use Illuminate\Support\Facades\Http;
 use Sfneal\Dependencies\Services\DependenciesService;
 use Sfneal\Dependencies\Tests\TestCase;
+use Sfneal\Dependencies\Utils\DependencySvg;
+use Sfneal\Dependencies\Utils\DependencyUrl;
 
 class DependencyServiceTest extends TestCase
 {
@@ -15,11 +17,11 @@ class DependencyServiceTest extends TestCase
      */
     public function github_url(string $package)
     {
-        $url = (new DependenciesService($package))
-            ->gitHub()
-            ->url();
+        $generator = (new DependenciesService($package))->gitHub();
+        $url = $generator->url();
         $response = Http::get($url);
 
+        $this->assertInstanceOf(DependencyUrl::class, $generator);
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('github.com', $url);
         $this->assertTrue($response->ok());
@@ -32,11 +34,11 @@ class DependencyServiceTest extends TestCase
      */
     public function travis_url(string $package)
     {
-        $url = (new DependenciesService($package))
-            ->travis()
-            ->url();
+        $generator = (new DependenciesService($package))->travis();
+        $url = $generator->url();
         $response = Http::get($url);
 
+        $this->assertInstanceOf(DependencyUrl::class, $generator);
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('travis-ci.com', $url);
         $this->assertTrue($response->ok());
@@ -49,11 +51,11 @@ class DependencyServiceTest extends TestCase
      */
     public function version_url(string $package)
     {
-        $url = (new DependenciesService($package))
-            ->version()
-            ->url();
+        $generator = (new DependenciesService($package))->version();
+        $url = $generator->url();
         $response = Http::get($url);
 
+        $this->assertInstanceOf(DependencyUrl::class, $generator);
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('packagist.org/packages', $url);
         $this->assertTrue($response->ok());
@@ -66,11 +68,12 @@ class DependencyServiceTest extends TestCase
      */
     public function travis_svg(string $package)
     {
-        $url = (new DependenciesService($package))
-            ->travis()
-            ->svg();
+        $generator = (new DependenciesService($package))->travis();
+        $url = $generator->svg();
         $response = Http::get($url);
 
+        $this->assertInstanceOf(DependencyUrl::class, $generator);
+        $this->assertInstanceOf(DependencySvg::class, $generator);
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('travis-ci.com', $url);
         $this->assertStringContainsString('.svg?branch=master', $url);
@@ -85,11 +88,12 @@ class DependencyServiceTest extends TestCase
      */
     public function version_svg(string $package)
     {
-        $url = (new DependenciesService($package))
-            ->version()
-            ->svg();
+        $generator = (new DependenciesService($package))->version();
+        $url = $generator->svg();
         $response = Http::get($url);
 
+        $this->assertInstanceOf(DependencyUrl::class, $generator);
+        $this->assertInstanceOf(DependencySvg::class, $generator);
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('img.shields.io/packagist/v', $url);
         $this->assertTrue($response->ok());
@@ -103,11 +107,12 @@ class DependencyServiceTest extends TestCase
      */
     public function last_commit_svg(string $package)
     {
-        $url = (new DependenciesService($package))
-            ->lastCommit()
-            ->svg();
+        $generator = (new DependenciesService($package))->lastCommit();
+        $url = $generator->svg();
         $response = Http::get($url);
 
+        $this->assertInstanceOf(DependencyUrl::class, $generator);
+        $this->assertInstanceOf(DependencySvg::class, $generator);
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('img.shields.io/github/last-commit', $url);
         $this->assertTrue($response->ok());

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -2,8 +2,6 @@
 
 namespace Sfneal\Dependencies\Tests\Feature;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Facades\Http;
 use Sfneal\Dependencies\Tests\TestCase;
 use Sfneal\Dependencies\Utils\DependenciesService;


### PR DESCRIPTION
- refactor test suite to use `Http` facade instead of `GuzzleHttp\Client`
- refactor `DependencyService` methods to return an instance of `DependencyUrl` for retrieving urls & svgs