### PR TITLE
Refactor `DependenciesRepository` to `Dependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,9 @@ All notable changes to `dependencies` will be documented in this file
 ## 0.3.0 - 2021-07-13
 - make `ComposerDependencies` utility for retrieving package dependencies from composer.json files
 - add 'composer_json_path' key to config for specifying the composer.json path
+
+
+## 0.4.0 - 2021-07-21
+- refactor retrieving dependencies syntax from `(new DependenciesRepository())->get()` to `Dependencies::fromConfig()->get()`
+- make `Dependencies` with static methods for constructing dependency collections 
+- refactor use of `DependenciesRepository` to allow for passing arrays of dependencies

--- a/src/Dependencies.php
+++ b/src/Dependencies.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Dependencies;
-
 
 use Sfneal\Dependencies\Services\DependenciesRepository;
 
@@ -40,4 +38,3 @@ class Dependencies
         return (new DependenciesRepository())->fromArray($dependencies);
     }
 }
-

--- a/src/Dependencies.php
+++ b/src/Dependencies.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Sfneal\Dependencies;
+
+
+use Sfneal\Dependencies\Services\DependenciesRepository;
+
+class Dependencies
+{
+    /**
+     * Retrieve dependencies from the composer.json file & optionally include 'dev' dependencies.
+     *
+     * @param bool $devComposerDependencies
+     * @return DependenciesRepository
+     */
+    public static function fromComposer(bool $devComposerDependencies = false): DependenciesRepository
+    {
+        return (new DependenciesRepository())->fromComposer($devComposerDependencies);
+    }
+
+    /**
+     * Retrieve dependencies from the config file.
+     *
+     * @return DependenciesRepository
+     */
+    public static function fromConfig(): DependenciesRepository
+    {
+        return (new DependenciesRepository())->fromConfig();
+    }
+
+    /**
+     * Retrieve dependencies from an array.
+     *
+     * @param array $dependencies
+     * @return DependenciesRepository
+     */
+    public static function fromArray(array $dependencies): DependenciesRepository
+    {
+        return (new DependenciesRepository())->fromArray($dependencies);
+    }
+}
+

--- a/tests/Unit/DependenciesRepositoryComposerTest.php
+++ b/tests/Unit/DependenciesRepositoryComposerTest.php
@@ -4,7 +4,7 @@ namespace Sfneal\Dependencies\Tests\Unit;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
-use Sfneal\Dependencies\DependenciesRepository;
+use Sfneal\Dependencies\Dependencies;
 use Sfneal\Dependencies\Services\DependenciesService;
 use Sfneal\Dependencies\Tests\TestCase;
 
@@ -24,8 +24,7 @@ class DependenciesRepositoryComposerTest extends TestCase
     /** @test */
     public function get_dependency_collection()
     {
-        $repo = new DependenciesRepository(true);
-        $collection = $repo->get();
+        $collection = Dependencies::fromComposer()->get();
 
         $this->assertInstanceOf(Collection::class, $collection);
         $this->assertSame(2, $collection->count());

--- a/tests/Unit/DependenciesRepositoryConfigEmptyTest.php
+++ b/tests/Unit/DependenciesRepositoryConfigEmptyTest.php
@@ -3,7 +3,7 @@
 namespace Sfneal\Dependencies\Tests\Unit;
 
 use Illuminate\Support\Collection;
-use Sfneal\Dependencies\DependenciesRepository;
+use Sfneal\Dependencies\Dependencies;
 use Sfneal\Dependencies\Tests\TestCase;
 
 class DependenciesRepositoryConfigEmptyTest extends TestCase
@@ -11,8 +11,7 @@ class DependenciesRepositoryConfigEmptyTest extends TestCase
     /** @test */
     public function get_dependency_empty_collection()
     {
-        $repo = new DependenciesRepository();
-        $collection = $repo->get();
+        $collection = Dependencies::fromConfig()->get();
 
         $this->assertInstanceOf(Collection::class, $collection);
         $this->assertSame(0, $collection->count());

--- a/tests/Unit/DependenciesRepositoryConfigEmptyTest.php
+++ b/tests/Unit/DependenciesRepositoryConfigEmptyTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sfneal\Dependencies\Tests\Unit;
+
+use Illuminate\Support\Collection;
+use Sfneal\Dependencies\DependenciesRepository;
+use Sfneal\Dependencies\Tests\TestCase;
+
+class DependenciesRepositoryConfigEmptyTest extends TestCase
+{
+    /** @test */
+    public function get_dependency_empty_collection()
+    {
+        $repo = new DependenciesRepository();
+        $collection = $repo->get();
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertSame(0, $collection->count());
+    }
+}

--- a/tests/Unit/DependenciesRepositoryConfigTest.php
+++ b/tests/Unit/DependenciesRepositoryConfigTest.php
@@ -4,7 +4,7 @@ namespace Sfneal\Dependencies\Tests\Unit;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
-use Sfneal\Dependencies\DependenciesRepository;
+use Sfneal\Dependencies\Dependencies;
 use Sfneal\Dependencies\Services\DependenciesService;
 use Sfneal\Dependencies\Tests\TestCase;
 
@@ -33,8 +33,7 @@ class DependenciesRepositoryConfigTest extends TestCase
     /** @test */
     public function get_dependency_collection()
     {
-        $repo = new DependenciesRepository();
-        $collection = $repo->get();
+        $collection = Dependencies::fromConfig()->get();
 
         $this->assertInstanceOf(Collection::class, $collection);
         $this->assertSame(5, $collection->count());


### PR DESCRIPTION
- refactor retrieving dependencies syntax from `(new DependenciesRepository())->get()` to `Dependencies::fromConfig()->get()`
- make `Dependencies` with static methods for constructing dependency collections 
- refactor use of `DependenciesRepository` to allow for passing arrays of dependencies

fixes #9 