### PR TITLE
Test support for Docker Hub repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,10 @@ All notable changes to `dependencies` will be documented in this file
 ## 0.6.1 - 2021-07-29
 - optimize repo & service tests by removing redundant http requests & assertions
 - cut packages with mismatching GitHub urls from `TestCase::packageProvider()`
+ 
+ 
+## 0.7.0 - 2021-08-17
+- add $type property setter to `DependenciesService` that asserts the dependency type is supported
+- refactor `DependenciesService::getGitHubPackageName()` method to `DependenciesService::setGitHubRepo()` & return void
+- fix issue with `DependenciesService::setGitHubRepo()` not using else statement for setting default value
+- add Docker repos to test dependencies

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -69,7 +69,7 @@ class DependenciesService
     {
         assert(
             in_array($type, self::DEPENDENCY_TYPES),
-            "'{$type} is not a supported dependency type (supported: " . join(', ', self::DEPENDENCY_TYPES)
+            "'{$type} is not a supported dependency type (supported: ".join(', ', self::DEPENDENCY_TYPES)
         );
         $this->type = $type;
     }

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -28,7 +28,7 @@ class DependenciesService
     /**
      * @var string Name of the GitHub package.
      */
-    public $packageGitubName;
+    public $githubRepo;
 
     /**
      * DependenciesService constructor.
@@ -38,7 +38,7 @@ class DependenciesService
     public function __construct(string $package, string $type = 'composer')
     {
         $this->package = $package;
-        $this->setGitHubPackageName($package);
+        $this->setGitHubRepo($package);
         $this->setType($type);
     }
 
@@ -48,16 +48,19 @@ class DependenciesService
      * @param string $fullPackageName
      * @return void
      */
-    private function setGitHubPackageName(string $fullPackageName): void
+    private function setGitHubRepo(string $fullPackageName): void
     {
         [$user, $package] = explode('/', $fullPackageName);
 
         // Replace GitHub username with alias if one is provided
         if (array_key_exists($user, config('dependencies.github_alias'))) {
-            $this->packageGitubName = config('dependencies.github_alias')[$user]."/{$package}";
+            $this->githubRepo = config('dependencies.github_alias')[$user]."/{$package}";
         }
 
-        $this->packageGitubName = $fullPackageName;
+        // Use default package name
+        else {
+            $this->githubRepo = $fullPackageName;
+        }
     }
 
     /**
@@ -81,7 +84,7 @@ class DependenciesService
      */
     public function gitHub(): DependencyUrl
     {
-        return new DependencyUrl("github.com/{$this->packageGitubName}");
+        return new DependencyUrl("github.com/{$this->githubRepo}");
     }
 
     /**
@@ -92,8 +95,8 @@ class DependenciesService
     public function travis(): DependencySvg
     {
         return new DependencySvg(
-            "travis-ci.com/{$this->packageGitubName}",
-            "travis-ci.com/{$this->packageGitubName}.svg?branch=master",
+            "travis-ci.com/{$this->githubRepo}",
+            "travis-ci.com/{$this->githubRepo}.svg?branch=master",
             ''
         );
     }
@@ -116,8 +119,8 @@ class DependenciesService
     public function lastCommit(): DependencySvg
     {
         return new DependencySvg(
-            "github.com/{$this->packageGitubName}",
-            "github/last-commit/{$this->packageGitubName}"
+            "github.com/{$this->githubRepo}",
+            "github/last-commit/{$this->githubRepo}"
         );
     }
 

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -8,7 +8,15 @@ use Sfneal\Dependencies\Utils\DependencyUrl;
 class DependenciesService
 {
     /**
-     * @var string Name of the sfneal composer dependency
+     * @var string[] Array of supported dependency types
+     */
+    private const DEPENDENCY_TYPES = [
+        'composer',
+        'docker',
+    ];
+
+    /**
+     * @var string Name of the dependency
      */
     public $package;
 
@@ -31,7 +39,7 @@ class DependenciesService
     {
         $this->package = $package;
         $this->packageGitubName = $this->getGitHubPackageName();
-        $this->type = $type;
+        $this->setType($type);
     }
 
     /**
@@ -49,6 +57,20 @@ class DependenciesService
         }
 
         return $this->package;
+    }
+
+    /**
+     * Set the dependencies type.
+     *
+     * @param string $type
+     */
+    private function setType(string $type): void
+    {
+        assert(
+            in_array($type, self::DEPENDENCY_TYPES),
+            "'{$type} is not a supported dependency type (supported: " . join(', ', self::DEPENDENCY_TYPES)
+        );
+        $this->type = $type;
     }
 
     /**

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -38,25 +38,26 @@ class DependenciesService
     public function __construct(string $package, string $type = 'composer')
     {
         $this->package = $package;
-        $this->packageGitubName = $this->getGitHubPackageName();
+        $this->setGitHubPackageName($package);
         $this->setType($type);
     }
 
     /**
      * Retrieve the GitHub package name with alias replacement.
      *
-     * @return string
+     * @param string $fullPackageName
+     * @return void
      */
-    private function getGitHubPackageName(): string
+    private function setGitHubPackageName(string $fullPackageName): void
     {
-        [$user, $package] = explode('/', $this->package);
+        [$user, $package] = explode('/', $fullPackageName);
 
         // Replace GitHub username with alias if one is provided
         if (array_key_exists($user, config('dependencies.github_alias'))) {
-            return config('dependencies.github_alias')[$user]."/{$package}";
+            $this->packageGitubName = config('dependencies.github_alias')[$user]."/{$package}";
         }
 
-        return $this->package;
+        $this->packageGitubName = $fullPackageName;
     }
 
     /**

--- a/tests/Feature/DependenciesServiceTest.php
+++ b/tests/Feature/DependenciesServiceTest.php
@@ -5,7 +5,7 @@ namespace Sfneal\Dependencies\Tests\Feature;
 use Sfneal\Dependencies\Services\DependenciesService;
 use Sfneal\Dependencies\Tests\TestCase;
 
-class DependencyServiceTest extends TestCase
+class DependenciesServiceTest extends TestCase
 {
     /**
      * @test

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -15,7 +15,8 @@ class DependencyServiceTest extends TestCase
      */
     public function travis_svg(string $package, string $type)
     {
-        $this->assertTravisSvg($package, (new DependenciesService($package, $type))->travis());
+        $service = (new DependenciesService($package, $type));
+        $this->assertTravisSvg($service->githubRepo, $service->travis());
     }
 
     /**
@@ -26,7 +27,8 @@ class DependencyServiceTest extends TestCase
      */
     public function version_svg(string $package, string $type)
     {
-        $this->assertVersionSvg($package, (new DependenciesService($package, $type))->version());
+        $service = (new DependenciesService($package, $type));
+        $this->assertVersionSvg($service->package, $service->version());
     }
 
     /**
@@ -37,7 +39,8 @@ class DependencyServiceTest extends TestCase
      */
     public function last_commit_svg(string $package, string $type)
     {
-        $this->assertLastCommitSvg($package, (new DependenciesService($package, $type))->lastCommit());
+        $service = (new DependenciesService($package, $type));
+        $this->assertLastCommitSvg($service->githubRepo, $service->lastCommit());
     }
 
     /**
@@ -48,7 +51,8 @@ class DependencyServiceTest extends TestCase
      */
     public function github_url(string $package, string $type)
     {
-        $this->assertGithubUrl($package, (new DependenciesService($package, $type))->gitHub());
+        $service = (new DependenciesService($package, $type));
+        $this->assertGithubUrl($service->githubRepo, $service->gitHub());
     }
 
     /**
@@ -59,7 +63,8 @@ class DependencyServiceTest extends TestCase
      */
     public function travis_url(string $package, string $type)
     {
-        $this->assertTravisUrl($package, (new DependenciesService($package, $type))->travis());
+        $service = (new DependenciesService($package, $type));
+        $this->assertTravisUrl($service->githubRepo, $service->travis());
     }
 
     /**
@@ -70,6 +75,7 @@ class DependencyServiceTest extends TestCase
      */
     public function version_url(string $package, string $type)
     {
-        $this->assertVersionUrl($package, (new DependenciesService($package, $type))->version());
+        $service = (new DependenciesService($package, $type));
+        $this->assertVersionUrl($service->package, $service->version());
     }
 }

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -11,59 +11,65 @@ class DependencyServiceTest extends TestCase
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function travis_svg(string $package)
+    public function travis_svg(string $package, string $type)
     {
-        $this->assertTravisSvg($package, (new DependenciesService($package))->travis());
+        $this->assertTravisSvg($package, (new DependenciesService($package, $type))->travis());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function version_svg(string $package)
+    public function version_svg(string $package, string $type)
     {
-        $this->assertVersionSvg($package, (new DependenciesService($package))->version());
+        $this->assertVersionSvg($package, (new DependenciesService($package, $type))->version());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function last_commit_svg(string $package)
+    public function last_commit_svg(string $package, string $type)
     {
-        $this->assertLastCommitSvg($package, (new DependenciesService($package))->lastCommit());
+        $this->assertLastCommitSvg($package, (new DependenciesService($package, $type))->lastCommit());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function github_url(string $package)
+    public function github_url(string $package, string $type)
     {
-        $this->assertGithubUrl($package, (new DependenciesService($package))->gitHub());
+        $this->assertGithubUrl($package, (new DependenciesService($package, $type))->gitHub());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function travis_url(string $package)
+    public function travis_url(string $package, string $type)
     {
-        $this->assertTravisUrl($package, (new DependenciesService($package))->travis());
+        $this->assertTravisUrl($package, (new DependenciesService($package, $type))->travis());
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function version_url(string $package)
+    public function version_url(string $package, string $type)
     {
-        $this->assertVersionUrl($package, (new DependenciesService($package))->version());
+        $this->assertVersionUrl($package, (new DependenciesService($package, $type))->version());
     }
 }

--- a/tests/Feature/DependencySvgTest.php
+++ b/tests/Feature/DependencySvgTest.php
@@ -39,9 +39,7 @@ class DependencySvgTest extends TestCase
                 "packagist.org/packages/{$repo}",
                 "packagist/v/{$repo}.svg",
             );
-        }
-
-        elseif ($type == 'docker') {
+        } elseif ($type == 'docker') {
             $svg = new DependencySvg(
                 "hub.docker.com/r/{$repo}",
                 "docker/v/{$repo}.svg?sort=semver"

--- a/tests/Feature/DependencySvgTest.php
+++ b/tests/Feature/DependencySvgTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Dependencies\Tests\Feature;
 
+use Sfneal\Dependencies\Services\DependenciesService;
 use Sfneal\Dependencies\Tests\TestCase;
 use Sfneal\Dependencies\Utils\DependencySvg;
 
@@ -11,12 +12,14 @@ class DependencySvgTest extends TestCase
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function travis_svg(string $package)
+    public function travis_svg(string $package, string $type)
     {
-        $this->assertTravisSvg($package, new DependencySvg(
-            "travis-ci.com/{$package}",
-            "travis-ci.com/{$package}.svg?branch=master",
+        $repo = (new DependenciesService($package, $type))->githubRepo;
+        $this->assertTravisSvg($repo, new DependencySvg(
+            "travis-ci.com/{$repo}",
+            "travis-ci.com/{$repo}.svg?branch=master",
             ''
         ));
     }
@@ -25,25 +28,41 @@ class DependencySvgTest extends TestCase
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function version_svg(string $package)
+    public function version_svg(string $package, string $type)
     {
-        $this->assertVersionSvg($package, new DependencySvg(
-            "packagist.org/packages/{$package}",
-            "packagist/v/{$package}.svg",
-        ));
+        $repo = (new DependenciesService($package, $type))->githubRepo;
+
+        if ($type == 'composer') {
+            $svg = new DependencySvg(
+                "packagist.org/packages/{$repo}",
+                "packagist/v/{$repo}.svg",
+            );
+        }
+
+        elseif ($type == 'docker') {
+            $svg = new DependencySvg(
+                "hub.docker.com/r/{$repo}",
+                "docker/v/{$repo}.svg?sort=semver"
+            );
+        }
+
+        $this->assertVersionSvg($repo, $svg);
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function last_commit_svg(string $package)
+    public function last_commit_svg(string $package, string $type)
     {
-        $this->assertLastCommitSvg($package, new DependencySvg(
-            "github.com/{$package}",
-            "github/last-commit/{$package}"
+        $repo = (new DependenciesService($package, $type))->githubRepo;
+        $this->assertLastCommitSvg($repo, new DependencySvg(
+            "github.com/{$repo}",
+            "github/last-commit/{$repo}"
         ));
     }
 }

--- a/tests/Feature/DependencyUrlTest.php
+++ b/tests/Feature/DependencyUrlTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Dependencies\Tests\Feature;
 
+use Sfneal\Dependencies\Services\DependenciesService;
 use Sfneal\Dependencies\Tests\TestCase;
 use Sfneal\Dependencies\Utils\DependencyUrl;
 
@@ -11,28 +12,33 @@ class DependencyUrlTest extends TestCase
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function github_url(string $package)
+    public function github_url(string $package, string $type)
     {
-        $this->assertGithubUrl($package, new DependencyUrl("github.com/{$package}"));
+        $repo = (new DependenciesService($package, $type))->githubRepo;
+        $this->assertGithubUrl($repo, new DependencyUrl("github.com/{$repo}"));
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function travis_url(string $package)
+    public function travis_url(string $package, string $type)
     {
-        $this->assertTravisUrl($package, new DependencyUrl("travis-ci.com/{$package}"));
+        $repo = (new DependenciesService($package, $type))->githubRepo;
+        $this->assertTravisUrl($repo, new DependencyUrl("travis-ci.com/{$repo}"));
     }
 
     /**
      * @test
      * @dataProvider packageProvider
      * @param string $package
+     * @param string $type
      */
-    public function version_url(string $package)
+    public function version_url(string $package, string $type)
     {
         $this->assertVersionUrl($package, new DependencyUrl("packagist.org/packages/{$package}"));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,21 +40,21 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     public function packageProvider(): array
     {
         $packages = [
-            ['sfneal/actions'],
-            ['sfneal/controllers'],
-            ['sfneal/laravel-helpers'],
-            ['sfneal/queueables'],
-            ['sfneal/redis-helpers'],
-            ['sfneal/scopes'],
-            ['sfneal/string-helpers'],
-            ['sfneal/time-helpers'],
-            ['sfneal/tracking'],
-            ['symfony/console'],
-            ['spatie/laravel-view-models'],
-            ['webmozart/assert'],
-            ['spatie/laravel-settings'],
-            ['illuminate/database'],
-            ['laravel/framework'],
+            ['sfneal/actions', 'composer'],
+            ['sfneal/controllers', 'composer'],
+            ['sfneal/laravel-helpers', 'composer'],
+            ['sfneal/queueables', 'composer'],
+            ['sfneal/redis-helpers', 'composer'],
+            ['sfneal/scopes', 'composer'],
+            ['sfneal/string-helpers', 'composer'],
+            ['sfneal/time-helpers', 'composer'],
+            ['sfneal/tracking', 'composer'],
+            ['symfony/console', 'composer'],
+            ['spatie/laravel-view-models', 'composer'],
+            ['webmozart/assert', 'composer'],
+            ['spatie/laravel-settings', 'composer'],
+            ['illuminate/database', 'composer'],
+            ['laravel/framework', 'composer'],
         ];
         shuffle($packages);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -55,6 +55,12 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             ['spatie/laravel-settings', 'composer'],
             ['illuminate/database', 'composer'],
             ['laravel/framework', 'composer'],
+            ['stephenneal/php-composer', 'docker'],
+            ['stephenneal/php-laravel', 'docker'],
+            ['stephenneal/nginx-laravel', 'docker'],
+            ['stephenneal/nginx-proxy', 'docker'],
+            ['stephenneal/node-yarn', 'docker'],
+            ['stephenneal/python-flask', 'docker'],
         ];
         shuffle($packages);
 
@@ -94,11 +100,11 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $this->assertSame($expected, $collection->count());
 
         $collection->each(function (DependenciesService $service) {
-            $this->assertTravisSvg($service->packageGitubName, $service->travis(), false);
+            $this->assertTravisSvg($service->githubRepo, $service->travis(), false);
             $this->assertVersionSvg($service->package, $service->version(), false);
-            $this->assertLastCommitSvg($service->packageGitubName, $service->lastCommit(), false);
-            $this->assertGithubUrl($service->packageGitubName, $service->gitHub(), false);
-            $this->assertTravisUrl($service->packageGitubName, $service->travis(), false);
+            $this->assertLastCommitSvg($service->githubRepo, $service->lastCommit(), false);
+            $this->assertGithubUrl($service->githubRepo, $service->gitHub(), false);
+            $this->assertTravisUrl($service->githubRepo, $service->travis(), false);
             $this->assertVersionUrl($service->package, $service->version(), false);
         });
     }

--- a/tests/Unit/DependenciesRepositoryConfigTest.php
+++ b/tests/Unit/DependenciesRepositoryConfigTest.php
@@ -16,10 +16,13 @@ class DependenciesRepositoryConfigTest extends TestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set(
-            'dependencies.dependencies.composer',
-            collect($this->packageProvider())->flatten()->toArray()
-        );
+        $packages = [];
+        foreach ($this->packageProvider() as $params) {
+            [$package, $type] = $params;
+            $packages[$type][] = $package;
+        }
+
+        $app['config']->set('dependencies.dependencies', $packages);
     }
 
     /** @test */

--- a/tests/Unit/DependenciesRepositoryConfigTest.php
+++ b/tests/Unit/DependenciesRepositoryConfigTest.php
@@ -16,11 +16,12 @@ class DependenciesRepositoryConfigTest extends TestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $packages = [];
-        foreach ($this->packageProvider() as $params) {
-            [$package, $type] = $params;
-            $packages[$type][] = $package;
-        }
+        $packages = collect($this->packageProvider())
+            ->mapToGroups(function (array $params, $key) {
+                [$package, $type] = $params;
+                return [$type => $package];
+            })
+            ->toArray();
 
         $app['config']->set('dependencies.dependencies', $packages);
     }

--- a/tests/Unit/DependenciesRepositoryConfigTest.php
+++ b/tests/Unit/DependenciesRepositoryConfigTest.php
@@ -19,6 +19,7 @@ class DependenciesRepositoryConfigTest extends TestCase
         $packages = collect($this->packageProvider())
             ->mapToGroups(function (array $params, $key) {
                 [$package, $type] = $params;
+
                 return [$type => $package];
             })
             ->toArray();


### PR DESCRIPTION
- add $type property setter to `DependenciesService` that asserts the dependency type is supported
- refactor `DependenciesService::getGitHubPackageName()` method to `DependenciesService::setGitHubRepo()` & return void
- fix issue with `DependenciesService::setGitHubRepo()` not using else statement for setting default value
- add Docker repos to test dependencies