### PR TITLE
Add use of `Http::retry()` to prevent failures from api limits

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -248,7 +248,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
      */
     private function sendRequest(string $url): Response
     {
-        $response = Http::get($url);
+        $response = Http::retry(3, 500)->get($url);
 
         $this->assertTrue($response->ok(), "Error: code {$response->status()} from {$url}");
 


### PR DESCRIPTION
- add use of `Http::retry()` to prevent tests from failing due to api request limits