### PR TITLE
Optimize `DependencyRepository` collection retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,8 @@ All notable changes to `dependencies` will be documented in this file
 
 # 1.0.1 - 2021-08-18
 - make `ComposerDependencyTest` for testing `ComposerDependencies` utility class
+
+
+# 1.1.0 - 2021-08-18
+- optimize `DependencyRepository::get()` method and related calls by reducing collection mapping
+- refactor ComposerDependencies return a flat collection composer packages (removed 'composer' value)

--- a/src/Services/DependenciesRepository.php
+++ b/src/Services/DependenciesRepository.php
@@ -128,7 +128,9 @@ class DependenciesRepository
      */
     private function getComposerRequirements(): Collection
     {
-        return (new ComposerDependencies($this->devComposerDependencies))->get();
+        return collect([
+            'composer' => (new ComposerDependencies($this->devComposerDependencies))->get()->toArray()
+        ]);
     }
 
     /**

--- a/src/Services/DependenciesRepository.php
+++ b/src/Services/DependenciesRepository.php
@@ -84,11 +84,16 @@ class DependenciesRepository
             $this->cacheKey(),
             config('dependencies.cache.ttl'),
             function () {
-                return $this->getDependencies()->mapWithKeys(function (array $dependencies, string $type) {
-                    return collect($dependencies)->map(function (string $dependency) use ($type) {
-                        return new DependenciesService($dependency, $type);
-                    });
-                });
+                // todo: optimize to use collections
+                $array = [];
+
+                foreach ($this->getDependencies()->toArray() as $type => $dependencies) {
+                    foreach ($dependencies as $dependency) {
+                        $array[] = new DependenciesService($dependency, $type);
+                    }
+                }
+
+                return collect($array);
             }
         );
     }

--- a/src/Services/DependenciesRepository.php
+++ b/src/Services/DependenciesRepository.php
@@ -134,7 +134,7 @@ class DependenciesRepository
     private function getComposerRequirements(): Collection
     {
         return collect([
-            'composer' => (new ComposerDependencies($this->devComposerDependencies))->get()->toArray()
+            'composer' => (new ComposerDependencies($this->devComposerDependencies))->get()->toArray(),
         ]);
     }
 

--- a/src/Services/DependenciesRepository.php
+++ b/src/Services/DependenciesRepository.php
@@ -135,7 +135,11 @@ class DependenciesRepository
      */
     private function getComposerRequirements(): Collection
     {
-        return (new ComposerDependencies($this->devComposerDependencies))->get();
+        return (new ComposerDependencies($this->devComposerDependencies))
+            ->get()
+            ->mapWithKeys(function(string $composerDep) {
+                return [$composerDep => 'composer'];
+            });
     }
 
     /**

--- a/src/Services/DependenciesRepository.php
+++ b/src/Services/DependenciesRepository.php
@@ -84,7 +84,6 @@ class DependenciesRepository
             $this->cacheKey(),
             config('dependencies.cache.ttl'),
             function () {
-                // todo: optimize to use collections
                 $array = [];
 
                 foreach ($this->getDependencies()->toArray() as $type => $dependencies) {

--- a/src/Utils/ComposerDependencies.php
+++ b/src/Utils/ComposerDependencies.php
@@ -7,7 +7,6 @@ use Sfneal\Helpers\Strings\StringHelpers;
 
 class ComposerDependencies
 {
-    // todo: add tests
     // todo: refactor to `ComposerRequirements`?
 
     /**
@@ -42,11 +41,6 @@ class ComposerDependencies
             // Remove 'php' & php extensions from the packages array
             ->filter(function (string $dep) {
                 return $dep != 'php' && ! (new StringHelpers($dep))->inString('ext');
-            })
-
-            // Map each dependencies to have a 'composer' value
-            ->mapWithKeys(function (string $dep) {
-                return [$dep => 'composer'];
             });
     }
 

--- a/tests/Feature/ComposerDependencyTest.php
+++ b/tests/Feature/ComposerDependencyTest.php
@@ -23,12 +23,11 @@ class ComposerDependencyTest extends TestCase
     /** @test */
     public function get_composer_dependencies()
     {
-        // todo: change to 1D array and add 'composer' values later
         $expected = [
-            'illuminate/support' => 'composer',
-            'sfneal/caching' => 'composer',
-            'sfneal/laravel-helpers' => 'composer',
-            'sfneal/string-helpers' => 'composer',
+            'illuminate/support',
+            'sfneal/caching',
+            'sfneal/laravel-helpers',
+            'sfneal/string-helpers',
         ];
         $deps = (new ComposerDependencies())->get();
 
@@ -38,16 +37,14 @@ class ComposerDependencyTest extends TestCase
     /** @test */
     public function get_composer_dependencies_dev()
     {
-        // todo: change to 1D array and add 'composer' values later
         $expected = [
-            'illuminate/support' => 'composer',
-            'sfneal/caching' => 'composer',
-            'sfneal/laravel-helpers' => 'composer',
-            'sfneal/string-helpers' => 'composer',
-            'phpunit/phpunit' => 'composer',
-            'orchestra/testbench' => 'composer',
-            'scrutinizer/ocular' => 'composer',
-
+            'illuminate/support',
+            'sfneal/caching',
+            'sfneal/laravel-helpers',
+            'sfneal/string-helpers',
+            'phpunit/phpunit',
+            'orchestra/testbench',
+            'scrutinizer/ocular',
         ];
         $deps = (new ComposerDependencies(true))->get();
 
@@ -64,6 +61,8 @@ class ComposerDependencyTest extends TestCase
     {
         $this->assertInstanceOf(Collection::class, $dependencies);
         $this->assertCount(count($expected), $dependencies);
-        $this->assertSame($expected, $dependencies->toArray());
+
+        // use `array_values()` to reindex array keys
+        $this->assertSame($expected, array_values($dependencies->toArray()));
     }
 }

--- a/tests/Unit/DependenciesRepositoryArrayTest.php
+++ b/tests/Unit/DependenciesRepositoryArrayTest.php
@@ -7,6 +7,8 @@ use Sfneal\Dependencies\Tests\TestCase;
 
 class DependenciesRepositoryArrayTest extends TestCase
 {
+    // todo: add python deps
+
     /** @test */
     public function get_dependency_collection_from_array_composer()
     {
@@ -40,7 +42,7 @@ class DependenciesRepositoryArrayTest extends TestCase
     }
 
     /** @test */
-    public function get_dependency_collection_from_array()
+    public function get_dependency_collection_from_array_all()
     {
         $collection = Dependencies::fromArray([
             'composer' => [


### PR DESCRIPTION
 - optimize `DependencyRepository::get()` method and related calls by reducing collection mapping
 - refactor ComposerDependencies return a flat collection composer packages (removed 'composer' value)
 
fixes #37