### PR TITLE
Support for sfneal/caching v2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,4 +85,5 @@ All notable changes to `dependencies` will be documented in this file
 
 
 # 1.1.1 - 2021-09-01
+- fix 'travis-ci.com' url to 'app.travis-ci.com' subdomain (was causing `DependenciesServiceTest::travis_url()` to fail)
 - add support for sfneal/caching v2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,3 +82,7 @@ All notable changes to `dependencies` will be documented in this file
 # 1.1.0 - 2021-08-18
 - optimize `DependencyRepository::get()` method and related calls by reducing collection mapping
 - refactor ComposerDependencies return a flat collection composer packages (removed 'composer' value)
+
+
+# 1.1.1 - 2021-09-01
+- add support for sfneal/caching v2.0

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "illuminate/support": ">=8.40",
-        "sfneal/caching": "^1.3",
+        "sfneal/caching": "^1.3|^2.0",
         "sfneal/laravel-helpers": "^2.4",
         "sfneal/string-helpers": "^1.0"
     },

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -117,8 +117,8 @@ class DependenciesService
     public function travis(): DependencySvg
     {
         return new DependencySvg(
-            "travis-ci.com/{$this->githubRepo}",
-            "travis-ci.com/{$this->githubRepo}.svg?branch=master",
+            "app.travis-ci.com/{$this->githubRepo}",
+            "app.travis-ci.com/{$this->githubRepo}.svg?branch=master",
             ''
         );
     }

--- a/tests/Feature/DependencySvgTest.php
+++ b/tests/Feature/DependencySvgTest.php
@@ -18,8 +18,8 @@ class DependencySvgTest extends TestCase
     {
         $repo = (new DependenciesService($package, $type))->githubRepo;
         $this->assertTravisSvg($repo, new DependencySvg(
-            "travis-ci.com/{$repo}",
-            "travis-ci.com/{$repo}.svg?branch=master",
+            "app.travis-ci.com/{$repo}",
+            "app.travis-ci.com/{$repo}.svg?branch=master",
             ''
         ));
     }

--- a/tests/Feature/DependencyUrlTest.php
+++ b/tests/Feature/DependencyUrlTest.php
@@ -29,7 +29,7 @@ class DependencyUrlTest extends TestCase
     public function travis_url(string $package, string $type)
     {
         $repo = (new DependenciesService($package, $type))->githubRepo;
-        $this->assertTravisUrl($repo, new DependencyUrl("travis-ci.com/{$repo}"));
+        $this->assertTravisUrl($repo, new DependencyUrl("app.travis-ci.com/{$repo}"));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -122,7 +122,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $this->assertInstanceOf(DependencyUrl::class, $generator);
         $this->assertInstanceOf(DependencySvg::class, $generator);
         $this->assertStringContainsString($package, $url);
-        $this->assertStringContainsString('travis-ci.com', $url);
+        $this->assertStringContainsString('app.travis-ci.com', $url);
         $this->assertStringContainsString('.svg?branch=master', $url);
 
         if ($sendRequest) {
@@ -209,7 +209,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
         $this->assertInstanceOf(DependencyUrl::class, $generator);
         $this->assertStringContainsString($package, $url);
-        $this->assertStringContainsString('travis-ci.com', $url);
+        $this->assertStringContainsString('app.travis-ci.com', $url);
 
         if ($sendRequest) {
             $response = $this->sendRequest($url);


### PR DESCRIPTION
- fix 'travis-ci.com' url to 'app.travis-ci.com' subdomain (was causing `DependenciesServiceTest::travis_url()` to fail)
- add support for sfneal/caching v2.0