### PR TITLE
Add 'red' color override to 'closed issues' svg badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,3 +91,7 @@ All notable changes to `dependencies` will be documented in this file
 
 # 1.2.0 - 2021-09-08
 - add ability to display 'open issues' & 'closed issues' badges for dependencies #43
+
+
+# 1.2.1 - 2021-09-08
+- add color override to 'closed issues' svg badge to force color to be red (makes it easier to read open vs. closed issues)

--- a/src/Services/DependenciesService.php
+++ b/src/Services/DependenciesService.php
@@ -180,7 +180,7 @@ class DependenciesService
     {
         return new DependencySvg(
             "github.com/{$this->githubRepo}/issues?q=is%3Aissue+is%3Aclosed",
-            "github/issues-closed-raw/{$this->githubRepo}"
+            "github/issues-closed-raw/{$this->githubRepo}?color=red"
         );
     }
 

--- a/tests/Feature/DependencySvgTest.php
+++ b/tests/Feature/DependencySvgTest.php
@@ -100,7 +100,7 @@ class DependencySvgTest extends TestCase
         $repo = (new DependenciesService($package, $type))->githubRepo;
         $this->assertClosedIssuesSvg($repo, new DependencySvg(
             "github.com/{$repo}/issues",
-            "github/issues-closed-raw/{$repo}"
+            "github/issues-closed-raw/{$repo}?color=red"
         ));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -274,6 +274,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $this->assertInstanceOf(DependencySvg::class, $generator);
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('github/issues-closed-raw', $url);
+        $this->assertStringContainsString('color=red', $url);
 
         if ($sendRequest) {
             $response = $this->sendRequest($url);
@@ -314,7 +315,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $this->assertStringContainsString($package, $url);
         $this->assertStringContainsString('github.com', $url);
         $this->assertStringContainsString('/issues', $url);
-        $this->assertStringContainsString('?q=is%3Aissue+is%3Aclosed', $url);
+        $this->assertStringContainsString('q=is%3Aissue+is%3Aclosed', $url);
 
         if ($sendRequest) {
             $response = $this->sendRequest($url);


### PR DESCRIPTION
- add color override to 'closed issues' svg badge to force color to be red (makes it easier to read open vs. closed issues)