### PR TITLE
Persistent HTTP testing cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,3 +113,7 @@ All notable changes to `dependencies` will be documented in this file
 # 1.4.1 - 2021-09-29
 - add static `from()` methods to `Url` & `ImgShieldsUrl` classes to allow for cleaner static construction of objects
 - refactor `ComposerDependencies` utility to `ComposerRequirements` to better reflect use
+
+
+# 1.4.2 - 2021-09-29
+- add persistent 'http' cache store for storing HTTP responses (reduces runtime of test suite, once response is received it shouldn't be expected to change)

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "test-feature": "vendor/bin/phpunit --testsuite='Feature Tests'",
         "test-unit": "vendor/bin/phpunit --testsuite='Unit Tests'",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "test-deploy": "composer update-test && composer docker-test-all",
         "docker-test": "bash scripts/boot.sh ''",
         "docker-test-lowest": "bash scripts/boot.sh --prefer-lowest",
         "docker-test-all": "bash scripts/boot-all.sh && bash scripts/boot-all.sh --prefer-lowest",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Psr\SimpleCache\InvalidArgumentException;
 use Sfneal\Dependencies\Providers\DependenciesServiceProvider;
 use Sfneal\Dependencies\Services\DependencyService;
 use Sfneal\Dependencies\Utils\DependencyUrl;
@@ -56,6 +57,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $app['config']->set('database.redis.default.port', env('REDIS_PORT', 6379));
         $app['config']->set('database.redis.default.options.prefix', null);
         $app['config']->set('cache.stores.redis.connection', 'default');
+
+        $app['config']->set('cache.stores.http.driver', 'redis');
+        $app['config']->set('cache.stores.http.connection', 'cache');
 
         $app['config']->set('dependencies.github_alias', ['stephenneal' => 'sfneal']);
     }
@@ -454,13 +458,20 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     /**
      * Send an HTTP request, validate its response is "Ok" & return the response.
      *
-     * @param  string  $url
+     * @param string $url
      * @return Response
+     * @throws InvalidArgumentException
      */
     private function sendRequest(string $url): Response
     {
-        $response = Http::retry(3, 500)->get($url);
+        $response = Cache::store('http')->rememberForever($url, function () use ($url) {
+            return Http::retry(3, 500)->get($url);
+        });
 
+        // Assert caching
+        $this->assertTrue(Cache::store('http')->has($url));
+
+        // Assert response
         $this->assertTrue($response->ok(), "Error: code {$response->status()} from {$url}");
 
         return $response;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,7 +58,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $app['config']->set('database.redis.default.options.prefix', null);
         $app['config']->set('cache.stores.redis.connection', 'default');
 
-        $app['config']->set('cache.stores.http.driver', 'redis');
+        $app['config']->set('cache.stores.http.driver', env('CACHE_DEFAULT', config('cache.default')));
         $app['config']->set('cache.stores.http.connection', 'cache');
 
         $app['config']->set('dependencies.github_alias', ['stephenneal' => 'sfneal']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -458,8 +458,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     /**
      * Send an HTTP request, validate its response is "Ok" & return the response.
      *
-     * @param string $url
+     * @param  string  $url
      * @return Response
+     *
      * @throws InvalidArgumentException
      */
     private function sendRequest(string $url): Response


### PR DESCRIPTION
- add persistent 'http' cache store for storing HTTP responses (reduces runtime of test suite, once response is received it shouldn't be expected to change)