### PR TITLE
GitHub Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,4 +125,6 @@ All notable changes to `dependencies` will be documented in this file
 
 
 # 1.5.0 - 2022-03-09
-- add `description()` method to `DependencyService::github()` for accessing a repo's description
+- add `description()` method to `DependencyService` for accessing a repo's description
+- add `defaultBranch()` method to `DependencyService` for accessing a repo's default branch
+- add `download()` method to `DependencyService` for downloading a zip of the repo's default branch

--- a/src/Services/DependencyService.php
+++ b/src/Services/DependencyService.php
@@ -66,10 +66,7 @@ class DependencyService
      */
     public function gitHub(): GithubUrl
     {
-        return new GithubUrl(
-            Url::from("github.com/{$this->githubRepo}"),
-            Url::from("api.github.com/repos/{$this->githubRepo}"),
-        );
+        return new GithubUrl($this->githubRepo);
     }
 
     /**

--- a/src/Utils/GithubUrl.php
+++ b/src/Utils/GithubUrl.php
@@ -14,15 +14,21 @@ class GithubUrl extends DependencyUrl
     private $api;
 
     /**
+     * @var string
+     */
+    private $githubRepo;
+
+    /**
      * GithubUrl Constructor.
      *
      * @param  string  $githubRepo  GitHub repo name
      */
     public function __construct(string $githubRepo)
     {
-        $this->api = Url::from("api.github.com/repos/{$githubRepo}");
+        $this->githubRepo = $githubRepo;
+        $this->api = Url::from("api.github.com/repos/{$this->githubRepo}");
 
-        parent::__construct(Url::from("github.com/{$githubRepo}"), null);
+        parent::__construct(Url::from("github.com/{$this->githubRepo}"), null);
     }
 
     /**
@@ -40,9 +46,19 @@ class GithubUrl extends DependencyUrl
      *
      * @return string
      */
-    public function defaultBranch(): ?string
+    public function defaultBranch(): string
     {
-        return $this->getApiResponse()->json('default_branch');
+        return $this->getApiResponse()->json('default_branch') ?? 'master';
+    }
+
+    /**
+     * Retrieve a link to download the GitHub repo zip.
+     *
+     * @return string
+     */
+    public function download(): string
+    {
+        return Url::from("github.com/{$this->githubRepo}/archive/refs/heads/{$this->defaultBranch()}.zip")->get();
     }
 
     /**

--- a/src/Utils/GithubUrl.php
+++ b/src/Utils/GithubUrl.php
@@ -15,7 +15,7 @@ class GithubUrl extends DependencyUrl
     /**
      * GithubUrl Constructor.
      *
-     * @param string $githubRepo GitHub repo name
+     * @param  string  $githubRepo  GitHub repo name
      */
     public function __construct(string $githubRepo)
     {

--- a/src/Utils/GithubUrl.php
+++ b/src/Utils/GithubUrl.php
@@ -36,6 +36,16 @@ class GithubUrl extends DependencyUrl
     }
 
     /**
+     * Retrieve the GitHub repo's description.
+     *
+     * @return string
+     */
+    public function defaultBranch(): ?string
+    {
+        return $this->getApiResponse()->json('default_branch');
+    }
+
+    /**
      * Retrieve a cached HTTP response from the GitHub api.
      *
      * @return ?Response
@@ -54,7 +64,7 @@ class GithubUrl extends DependencyUrl
 
         // Cache response
         return Cache::remember(
-            config('dependencies.cache.prefix').':api-responses:'.$this->api->get(),
+            config('dependencies.cache.prefix').':api-responses:'.crc32($this->api->get()),
             config('dependencies.cache.ttl'),
             function () use ($response): Response {
                 return $response;

--- a/src/Utils/GithubUrl.php
+++ b/src/Utils/GithubUrl.php
@@ -69,8 +69,8 @@ class GithubUrl extends DependencyUrl
     private function getApiResponse(): ?Response
     {
         $response = Http::withHeaders([
-                'Authorization' => 'token '.config('dependencies.github_pat'),
-            ])
+            'Authorization' => 'token '.config('dependencies.github_pat'),
+        ])
             ->get($this->api->get());
 
         // Client error

--- a/src/Utils/GithubUrl.php
+++ b/src/Utils/GithubUrl.php
@@ -15,13 +15,13 @@ class GithubUrl extends DependencyUrl
     /**
      * GithubUrl Constructor.
      *
-     * @param  Url  $url
-     * @param  Url  $api
+     * @param string $githubRepo GitHub repo name
      */
-    public function __construct(Url $url, Url $api)
+    public function __construct(string $githubRepo)
     {
-        parent::__construct($url, null);
-        $this->api = $api;
+        $this->api = Url::from("api.github.com/repos/{$githubRepo}");
+
+        parent::__construct(Url::from("github.com/{$githubRepo}"), null);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -253,11 +253,18 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $response = $this->sendRequest($url);
         }
 
-        // Description
+        // GitHub API
         if (! is_null(config('dependencies.github_pat'))) {
+
+            // Description
             $description = $generator->description();
-            $this->assertIsString($description);
             $this->assertNotNull($description);
+            $this->assertIsString($description);
+
+            // Default Branch
+            $defaultBranch = $generator->defaultBranch();
+            $this->assertNotNull($defaultBranch);
+            $this->assertIsString($defaultBranch);
         }
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -250,7 +250,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $this->assertStringContainsString('github.com', $url);
 
         if ($sendRequest) {
-            $response = $this->sendRequest($url);
+            $this->sendRequest($url);
         }
 
         // GitHub API
@@ -265,6 +265,14 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $defaultBranch = $generator->defaultBranch();
             $this->assertNotNull($defaultBranch);
             $this->assertIsString($defaultBranch);
+
+            // Download
+            $download = $generator->download();
+            $this->assertNotNull($download);
+            $this->assertIsString($download);
+            if ($sendRequest) {
+                $this->sendRequest($download);
+            }
         }
     }
 


### PR DESCRIPTION
- add `defaultBranch()` method to `DependencyService` for accessing a repo's default branch
- add `download()` method to `DependencyService` for downloading a zip of the repo's default branch