### PR TITLE
Node Project Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,3 +140,7 @@ All notable changes to `dependencies` will be documented in this file
 
 # 1.7.0 - 2022-03-10
 - add support for 'node' package dependencies
+
+
+# 1.7.1 - 2022-03-11
+- fix issue with `DependencyService::setProject()` including vendor name in 'node' projects

--- a/src/Services/DependencyService.php
+++ b/src/Services/DependencyService.php
@@ -299,7 +299,7 @@ class DependencyService
      */
     private function setProject(string $fullPackageName): void
     {
-        if ($this->type == 'python') {
+        if ($this->type == 'python' || $this->type == 'node') {
             [$user, $package] = explode('/', $fullPackageName);
             $this->project = $package;
         } else {

--- a/tests/Feature/DependencyServiceTest.php
+++ b/tests/Feature/DependencyServiceTest.php
@@ -80,7 +80,7 @@ class DependencyServiceTest extends TestCase
         $this->assertNotNull($service->project);
         $this->assertIsString($service->project);
 
-        if ($service->type == 'python') {
+        if ($service->type == 'python' || $service->type == 'node') {
             $this->assertEquals(
                 explode('/', $service->package)[1],
                 $service->project


### PR DESCRIPTION
- fix issue with `DependencyService::setProject()` including vendor name in 'node' projects