### PR TITLE
GitHub Release Badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,3 +144,7 @@ All notable changes to `dependencies` will be documented in this file
 
 # 1.7.1 - 2022-03-11
 - fix issue with `DependencyService::setProject()` including vendor name in 'node' projects
+
+ 
+# 1.8.0 - 2022-03-11
+- add `GithubUrl::release()` method for accessing the most recent version release

--- a/src/Utils/GithubUrl.php
+++ b/src/Utils/GithubUrl.php
@@ -86,6 +86,19 @@ class GithubUrl extends DependencyUrl
     }
 
     /**
+     * Display the latest GitHub release (by date) for a GitHub repo.
+     *
+     * @return DependencyUrl
+     */
+    public function release(): DependencyUrl
+    {
+        return new DependencyUrl(
+            ImgShieldsUrl::from("github/v/release/{$this->githubRepo}")
+                ->withGlobalParams($this->imgShieldGlobals)
+        );
+    }
+
+    /**
      * Retrieve a cached HTTP response from the GitHub api.
      *
      * @return ?array

--- a/tests/Feature/GithubUrlTest.php
+++ b/tests/Feature/GithubUrlTest.php
@@ -38,8 +38,8 @@ class GithubUrlTest extends TestCase
      * @test
      * @dataProvider packageProviderWithWorkflows
      *
-     * @param string $package
-     * @param string $type
+     * @param  string  $package
+     * @param  string  $type
      */
     public function github_url_public_methods(string $package, string $type)
     {

--- a/tests/Feature/GithubUrlTest.php
+++ b/tests/Feature/GithubUrlTest.php
@@ -38,11 +38,10 @@ class GithubUrlTest extends TestCase
      * @test
      * @dataProvider packageProviderWithWorkflows
      *
-     * @param  string  $package
-     * @param  string  $type
-     * @param  array  $workflows
+     * @param string $package
+     * @param string $type
      */
-    public function github_url_public_methods(string $package, string $type, array $workflows)
+    public function github_url_public_methods(string $package, string $type)
     {
         $github = new GithubUrl($package);
 
@@ -82,5 +81,23 @@ class GithubUrlTest extends TestCase
                 '"passing", "failing" or "not found" were not found in the badge (url: '.$url.')'
             );
         }
+    }
+
+    /**
+     * @test
+     * @dataProvider packageProviderWithWorkflows
+     */
+    public function github_release(string $package, string $type)
+    {
+        $github = new GithubUrl($package);
+        $url = $github->release()->url();
+
+        $this->assertInstanceOf(DependencyUrl::class, $github);
+        $this->assertStringContainsString($package, $url);
+        $this->assertStringContainsString('img.shields.io/github/v/release', $url);
+
+        $response = $this->sendRequest($url);
+
+        $this->assertStringContainsString('release', $response->body());
     }
 }


### PR DESCRIPTION
- add `GithubUrl::release()` method for accessing the most recent version release