### PR TITLE
`url` & `svg` Method Returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,3 +152,7 @@ All notable changes to `dependencies` will be documented in this file
 
 # 1.8.1 - 2022-03-11
 - add sorting by semver & including pre-releases to `GithubUrl::release()` method
+
+
+# 1.9.0 - 2022-03-11
+- fix issues with `workflow()` & `release()` methods not properly returning urls & svgs

--- a/src/Services/DependencyService.php
+++ b/src/Services/DependencyService.php
@@ -112,6 +112,7 @@ class DependencyService
         }
     }
 
+    // todo: refactor github related methods to GitHubUrl
     /**
      * Retrieve date of the last GitHub commit.
      *

--- a/src/Utils/GithubUrl.php
+++ b/src/Utils/GithubUrl.php
@@ -68,6 +68,16 @@ class GithubUrl extends DependencyUrl
     }
 
     /**
+     * Retrieve a link to the GitHub repo's workflow status page.
+     *
+     * @return string
+     */
+    public function actions(): string
+    {
+        return Url::from("github.com/{$this->githubRepo}/actions");
+    }
+
+    /**
      * Display pass/fail status for a GitHub repo's workflow.
      *
      * @param  string  $name
@@ -76,6 +86,7 @@ class GithubUrl extends DependencyUrl
     public function workflow(string $name): DependencyUrl
     {
         return new DependencyUrl(
+            $this->actions(),
             ImgShieldsUrl::from("github/workflow/status/{$this->githubRepo}/{$name}")
                 ->withGlobalParams($this->imgShieldGlobals)
                 ->withParams([
@@ -93,6 +104,7 @@ class GithubUrl extends DependencyUrl
     public function release(): DependencyUrl
     {
         return new DependencyUrl(
+            Url::from("github.com/{$this->githubRepo}/releases"),
             ImgShieldsUrl::from("github/v/release/{$this->githubRepo}")
                 ->withGlobalParams($this->imgShieldGlobals)
                 ->withParams([

--- a/src/Utils/GithubUrl.php
+++ b/src/Utils/GithubUrl.php
@@ -74,7 +74,7 @@ class GithubUrl extends DependencyUrl
      */
     public function actions(): string
     {
-        return Url::from("github.com/{$this->githubRepo}/actions");
+        return Url::from("github.com/{$this->githubRepo}/actions")->get();
     }
 
     /**
@@ -86,7 +86,7 @@ class GithubUrl extends DependencyUrl
     public function workflow(string $name): DependencyUrl
     {
         return new DependencyUrl(
-            $this->actions(),
+            Url::from("github.com/{$this->githubRepo}/actions"),
             ImgShieldsUrl::from("github/workflow/status/{$this->githubRepo}/{$name}")
                 ->withGlobalParams($this->imgShieldGlobals)
                 ->withParams([

--- a/tests/Feature/GithubUrlTest.php
+++ b/tests/Feature/GithubUrlTest.php
@@ -62,13 +62,14 @@ class GithubUrlTest extends TestCase
 
         foreach ($workflows as $workflow) {
             $generator = $github->workflow($workflow);
-            $url = $generator->url();
+            $svg = $generator->svg();
 
             $this->assertInstanceOf(DependencyUrl::class, $generator);
-            $this->assertStringContainsString($package, $url);
-            $this->assertStringContainsString('img.shields.io/github/workflow/status', $url);
+            $this->assertStringContainsString($package, $svg);
+            $this->assertStringContainsString("github.com/{$package}/actions", $generator->url());
+            $this->assertStringContainsString('img.shields.io/github/workflow/status', $svg);
 
-            $response = $this->sendRequest($url);
+            $response = $this->sendRequest($svg);
 
             $this->assertStringContainsString($workflow, $response->body());
 
@@ -78,7 +79,7 @@ class GithubUrlTest extends TestCase
                 $stringHelper->inString('passing')
                 || $stringHelper->inString('failing')
                 || $stringHelper->inString('not found'),
-                '"passing", "failing" or "not found" were not found in the badge (url: '.$url.')'
+                '"passing", "failing" or "not found" were not found in the badge (url: '.$svg.')'
             );
         }
     }
@@ -90,13 +91,14 @@ class GithubUrlTest extends TestCase
     public function github_release(string $package, string $type)
     {
         $github = new GithubUrl($package);
-        $url = $github->release()->url();
+        $svg = $github->release()->svg();
 
         $this->assertInstanceOf(DependencyUrl::class, $github);
-        $this->assertStringContainsString($package, $url);
-        $this->assertStringContainsString('img.shields.io/github/v/release', $url);
+        $this->assertStringContainsString($package, $svg);
+        $this->assertStringContainsString("github.com/{$package}/releases", $github->release()->url());
+        $this->assertStringContainsString('img.shields.io/github/v/release', $svg);
 
-        $response = $this->sendRequest($url);
+        $response = $this->sendRequest($svg);
 
         $this->assertStringContainsString('release', $response->body());
     }


### PR DESCRIPTION
- fix issues with `workflow()` & `release()` methods not properly returning urls & svgs