### PR TITLE
`from()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,3 +156,4 @@ All notable changes to `dependencies` will be documented in this file
 
 # 1.9.0 - 2022-03-11
 - fix issues with `workflow()` & `release()` methods not properly returning urls & svgs
+- add `Dependency::from()` method for retrieving an object for a single dependency

--- a/src/Dependencies.php
+++ b/src/Dependencies.php
@@ -3,9 +3,22 @@
 namespace Sfneal\Dependencies;
 
 use Sfneal\Dependencies\Services\DependenciesRepository;
+use Sfneal\Dependencies\Services\DependencyService;
 
 class Dependencies
 {
+    /**
+     * Retrieve a DependencyService for a single package.
+     *
+     * @param string $type
+     * @param string $package
+     * @return DependencyService
+     */
+    public static function from(string $type, string $package): DependencyService
+    {
+        return new DependencyService($package, $type);
+    }
+
     /**
      * Retrieve dependencies from the composer.json file & optionally include 'dev' dependencies.
      *

--- a/src/Dependencies.php
+++ b/src/Dependencies.php
@@ -10,8 +10,8 @@ class Dependencies
     /**
      * Retrieve a DependencyService for a single package.
      *
-     * @param string $type
-     * @param string $package
+     * @param  string  $type
+     * @param  string  $package
      * @return DependencyService
      */
     public static function from(string $type, string $package): DependencyService


### PR DESCRIPTION
- add `Dependency::from()` method for retrieving an object for a single dependency